### PR TITLE
Untertitel position, kein escape bei description

### DIFF
--- a/lib/video.php
+++ b/lib/video.php
@@ -211,14 +211,15 @@ class Video
             $code .= "<source src=\"" . rex_escape($sourceUrl) . "\" type=\"" . ($isAudio ? "audio/mp3" : "video/mp4") . "\" />";
         }
 
-        $code .= "</media-provider>";
-
+        // Move subtitles inside <media-provider>
         if (!$isAudio) {
             foreach ($this->subtitles as $subtitle) {
                 $defaultAttr = $subtitle['default'] ? ' default' : '';
                 $code .= "<track src=\"" . rex_escape($subtitle['src']) . "\" kind=\"" . rex_escape($subtitle['kind']) . "\" label=\"" . rex_escape($subtitle['label']) . "\" srclang=\"" . rex_escape($subtitle['lang']) . "\"{$defaultAttr} />";
             }
         }
+
+        $code .= "</media-provider>";
 
         $code .= $isAudio ? "<media-audio-layout></media-audio-layout>" :
             "<media-video-layout" . ($this->thumbnails ? " thumbnails=\"" . rex_escape($this->thumbnails) . "\"" : "") . "></media-video-layout>";

--- a/lib/video.php
+++ b/lib/video.php
@@ -60,7 +60,7 @@ class Video
         $alternativeUrl = $alternativeUrl ?: $this->getAlternativeUrl();
 
         $this->a11yContent = "<div class=\"video-description\">"
-            . "<p>" . rex_escape($this->getText('video_description')) . ": " . rex_escape($description) . "</p></div>"
+            . "<p>" . rex_escape($this->getText('video_description')) . ": " . $description . "</p></div>"
             . "<div class=\"alternative-links\">"
             . "<p>" . rex_escape($this->getText('video_alternative_view')) . ": <a href=\"" . rex_escape($alternativeUrl) . "\">"
             . rex_escape($this->getText('video_open_alternative_view')) . "</a></p>"


### PR DESCRIPTION
fixed: https://github.com/FriendsOfREDAXO/vidstack/issues/31
fixed: https://github.com/FriendsOfREDAXO/vidstack/issues/30

Diese Änderung ermöglicht es auch, HTML-formatierten Text in der Beschreibung zu verwenden. Allerdings ist es wichtig zu beachten, dass dies auch ein Sicherheitsrisiko darstellen kann

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the rendering of subtitles to ensure they are properly nested within the media provider element, enhancing the structural integrity of the HTML output for media players.
	- Updated the display of video descriptions to allow raw HTML rendering, improving formatting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->