### PR TITLE
fixes Non-static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Hier ist die erweiterte README mit den fehlenden Methoden und aktualisierten Beispielen:
-
 # [Vidstack.io](https://www.vidstack.io) for REDAXO
 
 ![Screenshot](https://github.com/FriendsOfREDAXO/vidstack/blob/assets/screenshot.png?raw=true)
@@ -408,5 +406,3 @@ flowchart TD
 
 **Thanks to**
 [Vidstack.io](https://www.vidstack.io)
-
-

--- a/lib/video.php
+++ b/lib/video.php
@@ -138,14 +138,14 @@ class Video
         return in_array(strtolower($pathInfo['extension'] ?? ''), $audioExtensions);
     }
 
-    private function getVideoInfo(): array
+    private static function getVideoInfo(string $source): array
     {
         $youtubePattern = '%(?:youtube(?:-nocookie)?\.com/(?:[^/]+/.+/|(?:v|e(?:mbed)?)/|.*[?&]v=|shorts/)|youtu\.be/)([^"&?/ ]{11})%i';
-        if (preg_match($youtubePattern, $this->source, $match)) {
+        if (preg_match($youtubePattern, $source, $match)) {
             return ['platform' => 'youtube', 'id' => $match[1]];
         }
         $vimeoPattern = '~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(progressive_redirect\/playback|external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix';
-        if (preg_match($vimeoPattern, $this->source, $match)) {
+        if (preg_match($vimeoPattern, $source, $match)) {
             return ['platform' => 'vimeo', 'id' => $match[2]];
         }
         return ['platform' => 'default', 'id' => ''];
@@ -170,7 +170,7 @@ class Video
 
     public function generateFull(): string
     {
-        $videoInfo = $this->getVideoInfo();
+        $videoInfo = self::getVideoInfo($this->source);
         $isAudio = self::isAudio($this->source);
         $mediaType = $isAudio ? 'audio' : 'video';
 
@@ -205,7 +205,7 @@ class Video
         $sourceUrl = $this->getSourceUrl();
         $isAudio = self::isAudio($this->source);
         $mediaType = $isAudio ? 'audio' : 'video';
-        $videoInfo = $this->getVideoInfo();
+        $videoInfo = self::getVideoInfo($this->source);
 
         $code = "<media-player{$titleAttr}{$attributesString}";
 


### PR DESCRIPTION
Non-static method FriendsOfRedaxo\VidStack\Video::getVideoInfo() cannot be called statically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced video information retrieval through a streamlined method.
	- Improved handling of subtitles within generated media output.

- **Bug Fixes**
	- Corrected method calls to ensure accurate source string usage.

- **Refactor**
	- Reorganized subtitle generation for better HTML structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->