### PR TITLE
Fix: Private Methoden für öffentlichen Zugriff geändert

### DIFF
--- a/lib/video.php
+++ b/lib/video.php
@@ -93,7 +93,7 @@ class Video
         ];
     }
 
-    private function getSourceUrl(): string
+    public function getSourceUrl(): string
     {
         if (filter_var($this->source, FILTER_VALIDATE_URL)) {
             return $this->source;
@@ -101,7 +101,7 @@ class Video
         return rex_url::media($this->source);
     }
 
-    private function getAlternativeUrl(): string
+    public function getAlternativeUrl(): string
     {
         return $this->getSourceUrl();
     }
@@ -140,7 +140,7 @@ class Video
         return in_array(strtolower($pathInfo['extension'] ?? ''), $audioExtensions);
     }
 
-    private static function getVideoInfo(string $source): array
+    public static function getVideoInfo(string $source): array
     {
         $youtubePattern = '%(?:youtube(?:-nocookie)?\.com/(?:[^/]+/.+/|(?:v|e(?:mbed)?)/|.*[?&]v=|shorts/)|youtu\.be/)([^"&?/ ]{11})%i';
         if (preg_match($youtubePattern, $source, $match)) {
@@ -246,7 +246,7 @@ class Video
         return $code;
     }
 
-    private function generateAttributesString(): string
+    public function generateAttributesString(): string
     {
         return array_reduce(array_keys($this->attributes), function ($carry, $key) {
             $value = $this->attributes[$key];
@@ -254,7 +254,7 @@ class Video
         }, '');
     }
 
-    private function generateConsentPlaceholder(string $consentText, string $platform, string $videoId): string
+    public function generateConsentPlaceholder(string $consentText, string $platform, string $videoId): string
     {
         $buttonText = $this->getText('Load Video');
         return "<div class=\"consent-placeholder\" aria-hidden=\"true\" data-platform=\"" . rex_escape($platform) . "\" data-video-id=\"" . rex_escape($videoId) . "\" style=\"aspect-ratio: 16/9;\">"

--- a/lib/video.php
+++ b/lib/video.php
@@ -93,6 +93,14 @@ class Video
         ];
     }
 
+    /**
+     * Retrieves the source URL of the video.
+     *
+     * If the source is a valid URL, it is returned as-is. Otherwise, it is treated as a media file
+     * and its URL is generated using the `rex_url::media` method.
+     *
+     * @return string The source URL of the video.
+     */
     public function getSourceUrl(): string
     {
         if (filter_var($this->source, FILTER_VALIDATE_URL)) {


### PR DESCRIPTION
fixes: https://github.com/FriendsOfREDAXO/vidstack/issues/36

## Beschreibung des Problems

In der aktuellen Implementierung sind die Methoden `getSourceUrl()`, `getAlternativeUrl()`, `getVideoInfo()`, `generateAttributesString()` und `generateConsentPlaceholder()` als `private` deklariert, obwohl sie in der README-Dokumentation als öffentlich zugängliche Methoden beschrieben werden. Dies führt zu Fehlermeldungen wie "Call to private method FriendsOfRedaxo\VidStack\Video::getSourceUrl() from scope rex_article_content" bei Verwendung dieser Methoden im Modul-Output.

## Implementierte Lösung

- Die oben genannten Methoden wurden von `private` zu `public` geändert, um sie wie in der Dokumentation beschrieben nutzbar zu machen.
- Die README-Dokumentation wurde mit praxisnäheren Beispielen erweitert, die zeigen, wie diese erweiterten Methoden in realen Szenarien sinnvoll eingesetzt werden können.

## Vorteile der Änderungen

- Konsistenz zwischen Code und Dokumentation
- Praktischere Beispiele für fortgeschrittene Anwendungsfälle
- Behebung der Fehlermeldung bei Verwendung im Modul-Output

Fixes #[IssueNummer] (falls vorhanden)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dokumentation**
  - Die README wurde um einen umfangreichen Abschnitt mit fünf praxisnahen PHP-Beispielen für fortgeschrittene Anwendungsfälle der Video-Klasse erweitert, darunter DSGVO-konformer Zwei-Klick-Player, Analytics-Integration, individuelles Player-Layout, adaptive Einbettung je nach Gerät und Integration mit REX_MEDIA-Variablen.

- **Refactor**
  - Mehrere Methoden der Video-Klasse sind nun öffentlich zugänglich, was die Nutzung erweiterter Funktionen in eigenen Projekten ermöglicht.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->